### PR TITLE
Fix middleware return value

### DIFF
--- a/lib/opentelemetry_tesla_middleware.ex
+++ b/lib/opentelemetry_tesla_middleware.ex
@@ -5,12 +5,5 @@ defmodule Tesla.Middleware.OpentelemetryTeslaMiddleware do
     env
     |> Tesla.put_headers(:otel_propagator.text_map_inject([]))
     |> Tesla.run(next)
-    |> case do
-      {:ok, env} ->
-        env
-
-      {:error, error} ->
-        {:error, error}
-    end
   end
 end

--- a/test/opentelemetry_tesla_middleware_test.exs
+++ b/test/opentelemetry_tesla_middleware_test.exs
@@ -9,11 +9,7 @@ defmodule OpentelemetryTeslaMiddlewareTest do
       %{kind: :client}
     )
 
-    assert %Tesla.Env{
-             headers: [
-               {"traceparent", traceparent}
-             ]
-           } =
+    assert {:ok, %Tesla.Env{headers: [{"traceparent", traceparent}]}} =
              Tesla.Middleware.OpentelemetryTeslaMiddleware.call(
                %Tesla.Env{url: ""},
                [],


### PR DESCRIPTION
[Tesla.Middleware][1] has a function signature:
```
call(env :: Tesla.Env.t(), next :: Tesla.Env.stack(), options :: any()) ::
  Tesla.Env.result()
```

where `Tesla.Env.result()` is `{:ok, t()} | {:error, any()}`.

Currently just `env` was returned. This broke other middlewares in the
chain. Instead, `{:ok, env}` should be returned. We can even just return
whatever `Tesla.run/2` returns which simplifies to code as well.

[1]: https://hexdocs.pm/tesla/Tesla.Middleware.html